### PR TITLE
Docker compose image tag update, Separate subcommand, Refactor docker and k8s subcommand runtime mode

### DIFF
--- a/bin/CM_OPERATOR_MODE
+++ b/bin/CM_OPERATOR_MODE
@@ -1,1 +1,0 @@
-DockerCompose

--- a/docker-compose-mode-files/docker-compose.yaml
+++ b/docker-compose-mode-files/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.7.2
+    image: cloudbaristaorg/cb-spider:0.8.8
     container_name: cb-spider
     ports:
       - "0.0.0.0:1024:1024"
@@ -30,7 +30,7 @@ services:
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.7.2
+    image: cloudbaristaorg/cb-tumblebug:0.8.4
     container_name: cb-tumblebug
     ports:
       - "0.0.0.0:1323:1323"
@@ -60,3 +60,15 @@ services:
       # - DB_USER=cb_tumblebug
       # - DB_PASSWORD=cb_tumblebug
       # - GODEBUG=netdns=go
+  cm-beetle:
+    image: cloudbaristaorg/cm-beetle:latest
+    container_name: cm-beetle
+    ports:
+      - "8056:8056"
+    depends_on:
+      - cb-tumblebug
+    environment:
+      - API_AUTH_ENABLED=true
+      - API_USERNAME=default
+      - API_PASSWORD=default
+      - LOGLEVEL=info

--- a/src/cmd/docker/info.go
+++ b/src/cmd/docker/info.go
@@ -1,4 +1,4 @@
-package framework
+package docker
 
 import (
 	"fmt"
@@ -20,34 +20,13 @@ var infoCmd = &cobra.Command{
 			fmt.Println("file is required")
 		} else {
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeDockerCompose:
-				common.SysCallDockerComposePs()
+			common.SysCallDockerComposePs()
 
-				fmt.Println("")
-				fmt.Println("[v]Status of Cloud-Migrator runtime images")
-				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s images", common.CMComposeProjectName, common.FileStr)
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
-			case common.ModeKubernetes:
-				fmt.Println("[v]Status of Cloud-Migrator Helm release")
-				cmdStr = fmt.Sprintf("helm status --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
-				common.SysCall(cmdStr)
-				fmt.Println()
-				fmt.Println("[v]Status of Cloud-Migrator pods")
-				cmdStr = fmt.Sprintf("kubectl get pods -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-				fmt.Println()
-				fmt.Println("[v]Status of Cloud-Migrator container images")
-				cmdStr = `kubectl get pods -n ` + common.CMK8sNamespace + ` -o jsonpath="{..image}" |\
-				tr -s '[[:space:]]' '\n' |\
-				sort |\
-				uniq`
-				common.SysCall(cmdStr)
-			default:
-
-			}
+			fmt.Println("")
+			fmt.Println("[v]Status of Cloud-Migrator runtime images")
+			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s images", common.CMComposeProjectName, common.FileStr)
+			//fmt.Println(cmdStr)
+			common.SysCall(cmdStr)
 		}
 	},
 }

--- a/src/cmd/docker/info.go
+++ b/src/cmd/docker/info.go
@@ -16,15 +16,14 @@ var infoCmd = &cobra.Command{
 		fmt.Println("\n[Get info for Cloud-Migrator runtimes]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.DockerFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			common.SysCallDockerComposePs()
 
 			fmt.Println("")
 			fmt.Println("[v]Status of Cloud-Migrator runtime images")
-			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s images", common.CMComposeProjectName, common.FileStr)
+			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s images", common.CMComposeProjectName, common.DockerFilePath)
 			//fmt.Println(cmdStr)
 			common.SysCall(cmdStr)
 		}
@@ -35,7 +34,7 @@ func init() {
 	dockerCmd.AddCommand(infoCmd)
 
 	pf := infoCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.DockerFilePath, "file", "f", common.DefaultDockerComposeConfig, "User-defined configuration file")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/src/cmd/docker/pull.go
+++ b/src/cmd/docker/pull.go
@@ -16,14 +16,10 @@ var pullCmd = &cobra.Command{
 		fmt.Println("\n[Pull images of Cloud-Migrator System containers]")
 		fmt.Println()
 
-		common.FileStr = common.GenConfigPath(common.FileStr, common.ModeDockerCompose)
-
-		if common.FileStr == "" {
+		if common.DockerFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-
-			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s pull", common.CMComposeProjectName, common.FileStr)
+			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s pull", common.CMComposeProjectName, common.DockerFilePath)
 			//fmt.Println(cmdStr)
 			common.SysCall(cmdStr)
 		}
@@ -35,7 +31,7 @@ func init() {
 	dockerCmd.AddCommand(pullCmd)
 
 	pf := pullCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.DockerFilePath, "file", "f", common.DefaultDockerComposeConfig, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 
 	// Here you will define your flags and configuration settings.

--- a/src/cmd/docker/pull.go
+++ b/src/cmd/docker/pull.go
@@ -1,4 +1,4 @@
-package framework
+package docker
 
 import (
 	"fmt"

--- a/src/cmd/docker/remove.go
+++ b/src/cmd/docker/remove.go
@@ -1,4 +1,4 @@
-package framework
+package docker
 
 import (
 	"fmt"
@@ -22,45 +22,20 @@ var removeCmd = &cobra.Command{
 		} else {
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeKubernetes:
-				cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
-				common.SysCall(cmdStr)
-
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-spider -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-tumblebug -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-ladybug -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-dragonfly -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-
-				cmdStr = fmt.Sprintf("kubectl delete pvc data-cm-mayfly-etcd-0 -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-
-				//fallthrough
-			case common.ModeDockerCompose:
-				if volFlag && imgFlag {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v --rmi all", common.CMComposeProjectName, common.FileStr)
-				} else if volFlag {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v", common.CMComposeProjectName, common.FileStr)
-				} else if imgFlag {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down --rmi all", common.CMComposeProjectName, common.FileStr)
-				} else {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down", common.CMComposeProjectName, common.FileStr)
-				}
-
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
-
-				common.SysCallDockerComposePs()
-			default:
-
+			if volFlag && imgFlag {
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v --rmi all", common.CMComposeProjectName, common.FileStr)
+			} else if volFlag {
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v", common.CMComposeProjectName, common.FileStr)
+			} else if imgFlag {
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down --rmi all", common.CMComposeProjectName, common.FileStr)
+			} else {
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down", common.CMComposeProjectName, common.FileStr)
 			}
+
+			//fmt.Println(cmdStr)
+			common.SysCall(cmdStr)
+
+			common.SysCallDockerComposePs()
 		}
 
 	},

--- a/src/cmd/docker/remove.go
+++ b/src/cmd/docker/remove.go
@@ -17,19 +17,18 @@ var removeCmd = &cobra.Command{
 		fmt.Println("\n[Remove Cloud-Migrator]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.DockerFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
 			if volFlag && imgFlag {
-				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v --rmi all", common.CMComposeProjectName, common.FileStr)
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v --rmi all", common.CMComposeProjectName, common.DockerFilePath)
 			} else if volFlag {
-				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v", common.CMComposeProjectName, common.FileStr)
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v", common.CMComposeProjectName, common.DockerFilePath)
 			} else if imgFlag {
-				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down --rmi all", common.CMComposeProjectName, common.FileStr)
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down --rmi all", common.CMComposeProjectName, common.DockerFilePath)
 			} else {
-				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down", common.CMComposeProjectName, common.FileStr)
+				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down", common.CMComposeProjectName, common.DockerFilePath)
 			}
 
 			//fmt.Println(cmdStr)
@@ -48,7 +47,7 @@ func init() {
 	dockerCmd.AddCommand(removeCmd)
 
 	pf := removeCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.DockerFilePath, "file", "f", common.DefaultDockerComposeConfig, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 
 	pf.BoolVarP(&volFlag, "volumes", "v", false, "Remove named volumes declared in the volumes section of the Compose file")

--- a/src/cmd/docker/root.go
+++ b/src/cmd/docker/root.go
@@ -1,7 +1,7 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 */
-package framework
+package docker
 
 import (
 	"fmt"

--- a/src/cmd/docker/run.go
+++ b/src/cmd/docker/run.go
@@ -1,11 +1,7 @@
-package framework
+package docker
 
 import (
 	"fmt"
-	"strings"
-
-	root "github.com/cm-mayfly/cm-mayfly/src/cmd"
-
 	"github.com/cm-mayfly/cm-mayfly/src/common"
 	"github.com/spf13/cobra"
 )
@@ -24,60 +20,11 @@ var runCmd = &cobra.Command{
 		} else {
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 
-			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeDockerCompose:
-				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s up", common.CMComposeProjectName, common.FileStr)
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
-			case common.ModeKubernetes:
-				if root.K8sprovider == common.NotDefined {
-					fmt.Print(`--k8sprovider argument is required but not provided.
-					e.g.
-					--k8sprovider=gke
-					--k8sprovider=eks
-					--k8sprovider=aks
-					--k8sprovider=mcks
-					--k8sprovider=minikube
-					--k8sprovider=kubeadm
-					`)
-
-					break
-				}
-
-				// For Kubernetes 1.19 and above
-				cmdStr = fmt.Sprintf("kubectl create ns %s --dry-run=client -o yaml | kubectl apply -f -", common.CMK8sNamespace)
-				// For Kubernetes 1.18 and below
-				//cmdStr = fmt.Sprintf("kubectl create ns %s --dry-run -o yaml | kubectl apply -f -", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-
-				// cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
-				// if strings.ToLower(k8sprovider) == "gke" {
-				// 	cmdStr += " --set metricServer.enabled=false"
-				// }
-				// //fmt.Println(cmdStr)
-				// common.SysCall(cmdStr)
-
-				if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "eks" || strings.ToLower(root.K8sprovider) == "aks" {
-					cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
-					cmdStr += " --set cb-restapigw.service.type=LoadBalancer"
-					cmdStr += " --set cb-webtool.service.type=LoadBalancer"
-
-					if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "aks" {
-						cmdStr += " --set metricServer.enabled=false"
-					}
-
-					common.SysCall(cmdStr)
-				} else {
-					cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
-					common.SysCall(cmdStr)
-				}
-			default:
-
-			}
+			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s up", common.CMComposeProjectName, common.FileStr)
+			//fmt.Println(cmdStr)
+			common.SysCall(cmdStr)
 
 		}
-
 	},
 }
 

--- a/src/cmd/docker/run.go
+++ b/src/cmd/docker/run.go
@@ -15,12 +15,10 @@ var runCmd = &cobra.Command{
 		fmt.Println("\n[Setup and Run Cloud-Migrator]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.DockerFilePath == "" {
 			fmt.Println("--file (-f) argument is required but not provided.")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-
-			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s up", common.CMComposeProjectName, common.FileStr)
+			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s up", common.CMComposeProjectName, common.DockerFilePath)
 			//fmt.Println(cmdStr)
 			common.SysCall(cmdStr)
 
@@ -32,7 +30,7 @@ func init() {
 	dockerCmd.AddCommand(runCmd)
 
 	pf := runCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.DockerFilePath, "file", "f", common.DefaultDockerComposeConfig, "User-defined configuration file")
 	//pf.StringVarP(&k8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services") //@todo
 
 	// runCmd.MarkPersistentFlagRequired("k8sprovider")

--- a/src/cmd/docker/stop.go
+++ b/src/cmd/docker/stop.go
@@ -16,12 +16,10 @@ var stopCmd = &cobra.Command{
 		fmt.Println("\n[Stop Cloud-Migrator]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.DockerFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-
-			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop", common.CMComposeProjectName, common.FileStr)
+			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop", common.CMComposeProjectName, common.DockerFilePath)
 			//fmt.Println(cmdStr)
 			common.SysCall(cmdStr)
 
@@ -35,7 +33,7 @@ func init() {
 	dockerCmd.AddCommand(stopCmd)
 
 	pf := stopCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.DockerFilePath, "file", "f", common.DefaultDockerComposeConfig, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 	// Here you will define your flags and configuration settings.
 

--- a/src/cmd/docker/stop.go
+++ b/src/cmd/docker/stop.go
@@ -1,4 +1,4 @@
-package framework
+package docker
 
 import (
 	"fmt"
@@ -20,20 +20,12 @@ var stopCmd = &cobra.Command{
 			fmt.Println("file is required")
 		} else {
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeDockerCompose:
-				cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop", common.CMComposeProjectName, common.FileStr)
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
 
-				common.SysCallDockerComposePs()
-			case common.ModeKubernetes:
-				cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
-				common.SysCall(cmdStr)
-			default:
+			cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop", common.CMComposeProjectName, common.FileStr)
+			//fmt.Println(cmdStr)
+			common.SysCall(cmdStr)
 
-			}
+			common.SysCallDockerComposePs()
 		}
 
 	},

--- a/src/cmd/k8s/info.go
+++ b/src/cmd/k8s/info.go
@@ -16,10 +16,9 @@ var infoCmd = &cobra.Command{
 		fmt.Println("\n[Get info for Cloud-Migrator runtimes]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.K8sFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
 
 			fmt.Println("[v]Status of Cloud-Migrator Helm release")
@@ -45,7 +44,7 @@ func init() {
 	k8sCmd.AddCommand(infoCmd)
 
 	pf := infoCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.K8sFilePath, "file", "f", common.DefaultKubernetesConfig, "User-defined configuration file")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/src/cmd/k8s/info.go
+++ b/src/cmd/k8s/info.go
@@ -1,4 +1,4 @@
-package framework
+package k8s
 
 import (
 	"fmt"
@@ -21,33 +21,22 @@ var infoCmd = &cobra.Command{
 		} else {
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeDockerCompose:
-				common.SysCallDockerComposePs()
 
-				fmt.Println("")
-				fmt.Println("[v]Status of Cloud-Migrator runtime images")
-				cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s images", common.CMComposeProjectName, common.FileStr)
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
-			case common.ModeKubernetes:
-				fmt.Println("[v]Status of Cloud-Migrator Helm release")
-				cmdStr = fmt.Sprintf("helm status --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
-				common.SysCall(cmdStr)
-				fmt.Println()
-				fmt.Println("[v]Status of Cloud-Migrator pods")
-				cmdStr = fmt.Sprintf("kubectl get pods -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
-				fmt.Println()
-				fmt.Println("[v]Status of Cloud-Migrator container images")
-				cmdStr = `kubectl get pods -n ` + common.CMK8sNamespace + ` -o jsonpath="{..image}" |\
+			fmt.Println("[v]Status of Cloud-Migrator Helm release")
+			cmdStr = fmt.Sprintf("helm status --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
+			common.SysCall(cmdStr)
+			fmt.Println()
+			fmt.Println("[v]Status of Cloud-Migrator pods")
+			cmdStr = fmt.Sprintf("kubectl get pods -n %s", common.CMK8sNamespace)
+			common.SysCall(cmdStr)
+			fmt.Println()
+			fmt.Println("[v]Status of Cloud-Migrator container images")
+			cmdStr = `kubectl get pods -n ` + common.CMK8sNamespace + ` -o jsonpath="{..image}" |\
 				tr -s '[[:space:]]' '\n' |\
 				sort |\
 				uniq`
-				common.SysCall(cmdStr)
-			default:
+			common.SysCall(cmdStr)
 
-			}
 		}
 	},
 }

--- a/src/cmd/k8s/installWeaveScope.go
+++ b/src/cmd/k8s/installWeaveScope.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	root "github.com/cm-mayfly/cm-mayfly/src/cmd"
 	"github.com/cm-mayfly/cm-mayfly/src/common"
 	"github.com/spf13/cobra"
 )
@@ -18,11 +17,9 @@ var installWeaveScopeCmd = &cobra.Command{
 		fmt.Println("\n[Install Weave Scope]")
 		fmt.Println()
 
-		common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-
 		var cmdStr string
 
-		if root.K8sprovider == common.NotDefined {
+		if K8sprovider == common.NotDefined {
 			fmt.Print(`--k8sprovider argument is required but not provided.
 					e.g.
 					--k8sprovider=gke
@@ -37,12 +34,12 @@ var installWeaveScopeCmd = &cobra.Command{
 		}
 
 		// If your cluster is on GKE, first you need to grant permissions for the installation.
-		if strings.ToLower(root.K8sprovider) == "gke" {
+		if strings.ToLower(K8sprovider) == "gke" {
 			cmdStr = `kubectl create clusterrolebinding "cluster-admin-$(whoami)" --clusterrole=cluster-admin --user="$(gcloud config get-value core/account)"`
 			common.SysCall(cmdStr)
 		}
 
-		if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "eks" || strings.ToLower(root.K8sprovider) == "aks" {
+		if strings.ToLower(K8sprovider) == "gke" || strings.ToLower(K8sprovider) == "eks" || strings.ToLower(K8sprovider) == "aks" {
 
 			// Install Weave Scope on your Kubernetes cluster.
 			cmdStr = `kubectl apply -f "https://cloud.weave.works/k8s/scope.yaml?k8s-version=$(kubectl version | base64 | tr -d '\n')&k8s-service-type=LoadBalancer"`
@@ -72,9 +69,9 @@ var installWeaveScopeCmd = &cobra.Command{
 func init() {
 	weaveScopeCmd.AddCommand(installWeaveScopeCmd)
 
-	// pf := installWeaveScopeCmd.PersistentFlags()
-	// // pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
-	// pf.StringVarP(&k8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
+	//pf := installWeaveScopeCmd.PersistentFlags()
+	//pf.StringVarP(&common.K8sFilePath, "file", "f", common.DefaultKubernetesConfig, "User-defined configuration file")
+	//pf.StringVarP(&K8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
 
 	/*
 		switch common.CMMayflyMode {

--- a/src/cmd/k8s/remove.go
+++ b/src/cmd/k8s/remove.go
@@ -1,4 +1,4 @@
-package framework
+package k8s
 
 import (
 	"fmt"
@@ -22,45 +22,24 @@ var removeCmd = &cobra.Command{
 		} else {
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeKubernetes:
-				cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
-				common.SysCall(cmdStr)
 
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-spider -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
+			cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
+			common.SysCall(cmdStr)
 
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-tumblebug -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
+			cmdStr = fmt.Sprintf("kubectl delete pvc cb-spider -n %s", common.CMK8sNamespace)
+			common.SysCall(cmdStr)
 
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-ladybug -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
+			cmdStr = fmt.Sprintf("kubectl delete pvc cb-tumblebug -n %s", common.CMK8sNamespace)
+			common.SysCall(cmdStr)
 
-				cmdStr = fmt.Sprintf("kubectl delete pvc cb-dragonfly -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
+			cmdStr = fmt.Sprintf("kubectl delete pvc cb-ladybug -n %s", common.CMK8sNamespace)
+			common.SysCall(cmdStr)
 
-				cmdStr = fmt.Sprintf("kubectl delete pvc data-cm-mayfly-etcd-0 -n %s", common.CMK8sNamespace)
-				common.SysCall(cmdStr)
+			cmdStr = fmt.Sprintf("kubectl delete pvc cb-dragonfly -n %s", common.CMK8sNamespace)
+			common.SysCall(cmdStr)
 
-				//fallthrough
-			case common.ModeDockerCompose:
-				if volFlag && imgFlag {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v --rmi all", common.CMComposeProjectName, common.FileStr)
-				} else if volFlag {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down -v", common.CMComposeProjectName, common.FileStr)
-				} else if imgFlag {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down --rmi all", common.CMComposeProjectName, common.FileStr)
-				} else {
-					cmdStr = fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s down", common.CMComposeProjectName, common.FileStr)
-				}
-
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
-
-				common.SysCallDockerComposePs()
-			default:
-
-			}
+			cmdStr = fmt.Sprintf("kubectl delete pvc data-cm-mayfly-etcd-0 -n %s", common.CMK8sNamespace)
+			common.SysCall(cmdStr)
 		}
 
 	},

--- a/src/cmd/k8s/remove.go
+++ b/src/cmd/k8s/remove.go
@@ -17,10 +17,9 @@ var removeCmd = &cobra.Command{
 		fmt.Println("\n[Remove Cloud-Migrator]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.K8sFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
 
 			cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
@@ -52,7 +51,7 @@ func init() {
 	k8sCmd.AddCommand(removeCmd)
 
 	pf := removeCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.K8sFilePath, "file", "f", common.DefaultKubernetesConfig, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 
 	pf.BoolVarP(&volFlag, "volumes", "v", false, "Remove named volumes declared in the volumes section of the Compose file")

--- a/src/cmd/k8s/root.go
+++ b/src/cmd/k8s/root.go
@@ -1,7 +1,7 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 */
-package framework
+package k8s
 
 import (
 	"fmt"

--- a/src/cmd/k8s/root.go
+++ b/src/cmd/k8s/root.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var K8sprovider string
+
 // restCmd represents the rest command
 var k8sCmd = &cobra.Command{
 	Use: "k8s",

--- a/src/cmd/k8s/run.go
+++ b/src/cmd/k8s/run.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	root "github.com/cm-mayfly/cm-mayfly/src/cmd"
-
 	"github.com/cm-mayfly/cm-mayfly/src/common"
 	"github.com/spf13/cobra"
 )
@@ -19,13 +17,11 @@ var runCmd = &cobra.Command{
 		fmt.Println("\n[Setup and Run Cloud-Migrator]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.K8sFilePath == "" {
 			fmt.Println("--file (-f) argument is required but not provided.")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-
 			var cmdStr string
-			if root.K8sprovider == common.NotDefined {
+			if K8sprovider == common.NotDefined {
 				fmt.Print(`--k8sprovider argument is required but not provided.
 					e.g.
 					--k8sprovider=gke
@@ -45,25 +41,25 @@ var runCmd = &cobra.Command{
 			//cmdStr = fmt.Sprintf("kubectl create ns %s --dry-run -o yaml | kubectl apply -f -", common.CMK8sNamespace)
 			common.SysCall(cmdStr)
 
-			// cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
+			// cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.K8sFilePath)
 			// if strings.ToLower(k8sprovider) == "gke" {
 			// 	cmdStr += " --set metricServer.enabled=false"
 			// }
 			// //fmt.Println(cmdStr)
 			// common.SysCall(cmdStr)
 
-			if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "eks" || strings.ToLower(root.K8sprovider) == "aks" {
-				cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
+			if strings.ToLower(K8sprovider) == "gke" || strings.ToLower(K8sprovider) == "eks" || strings.ToLower(K8sprovider) == "aks" {
+				cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.K8sFilePath)
 				cmdStr += " --set cb-restapigw.service.type=LoadBalancer"
 				cmdStr += " --set cb-webtool.service.type=LoadBalancer"
 
-				if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "aks" {
+				if strings.ToLower(K8sprovider) == "gke" || strings.ToLower(K8sprovider) == "aks" {
 					cmdStr += " --set metricServer.enabled=false"
 				}
 
 				common.SysCall(cmdStr)
 			} else {
-				cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
+				cmdStr = fmt.Sprintf("helm install --namespace %s %s -f %s ../helm-chart --debug", common.CMK8sNamespace, common.CMHelmReleaseName, common.K8sFilePath)
 				common.SysCall(cmdStr)
 			}
 
@@ -76,8 +72,8 @@ func init() {
 	k8sCmd.AddCommand(runCmd)
 
 	pf := runCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
-	//pf.StringVarP(&k8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services") //@todo
+	pf.StringVarP(&common.K8sFilePath, "file", "f", common.DefaultKubernetesConfig, "User-defined configuration file")
+	//pf.StringVarP(&K8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services") //@todo
 
 	// runCmd.MarkPersistentFlagRequired("k8sprovider")
 

--- a/src/cmd/k8s/stop.go
+++ b/src/cmd/k8s/stop.go
@@ -16,10 +16,9 @@ var stopCmd = &cobra.Command{
 		fmt.Println("\n[Stop Cloud-Migrator]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.K8sFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
 
 			cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
@@ -34,7 +33,7 @@ func init() {
 	k8sCmd.AddCommand(stopCmd)
 
 	pf := stopCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&common.K8sFilePath, "file", "f", common.DefaultKubernetesConfig, "User-defined configuration file")
 	//	cobra.MarkFlagRequired(pf, "file")
 	// Here you will define your flags and configuration settings.
 

--- a/src/cmd/k8s/stop.go
+++ b/src/cmd/k8s/stop.go
@@ -1,4 +1,4 @@
-package framework
+package k8s
 
 import (
 	"fmt"
@@ -21,19 +21,10 @@ var stopCmd = &cobra.Command{
 		} else {
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeDockerCompose:
-				cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s stop", common.CMComposeProjectName, common.FileStr)
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
 
-				common.SysCallDockerComposePs()
-			case common.ModeKubernetes:
-				cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
-				common.SysCall(cmdStr)
-			default:
+			cmdStr = fmt.Sprintf("helm uninstall --namespace %s %s", common.CMK8sNamespace, common.CMHelmReleaseName)
+			common.SysCall(cmdStr)
 
-			}
 		}
 
 	},

--- a/src/cmd/k8s/uninstallWeaveScope.go
+++ b/src/cmd/k8s/uninstallWeaveScope.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	root "github.com/cm-mayfly/cm-mayfly/src/cmd"
-
 	"github.com/cm-mayfly/cm-mayfly/src/common"
 	"github.com/spf13/cobra"
 )
@@ -19,17 +17,15 @@ var uninstallWeaveScopeCmd = &cobra.Command{
 		fmt.Println("\n[Uninstall Weave Scope]")
 		fmt.Println()
 
-		common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-
 		var cmdStr string
 
 		// If your cluster is on GKE, first you need to grant permissions for the uninstallation.
-		if strings.ToLower(root.K8sprovider) == "gke" {
+		if strings.ToLower(K8sprovider) == "gke" {
 			cmdStr = `kubectl delete clusterrolebinding "cluster-admin-$(whoami)"`
 			common.SysCall(cmdStr)
 		}
 
-		if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "eks" || strings.ToLower(root.K8sprovider) == "aks" {
+		if strings.ToLower(K8sprovider) == "gke" || strings.ToLower(K8sprovider) == "eks" || strings.ToLower(K8sprovider) == "aks" {
 
 			// Uninstall Weave Scope on your Kubernetes cluster.
 			cmdStr = `kubectl delete -f "https://cloud.weave.works/k8s/scope.yaml?k8s-version=$(kubectl version | base64 | tr -d '\n')&k8s-service-type=LoadBalancer"`
@@ -52,8 +48,8 @@ func init() {
 	weaveScopeCmd.AddCommand(uninstallWeaveScopeCmd)
 
 	// pf := uninstallWeaveScopeCmd.PersistentFlags()
-	// // pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
-	// pf.StringVarP(&k8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
+	// // pf.StringVarP(&common.K8sFilePath, "file", "f", common.NotDefined, "User-defined configuration file")
+	// pf.StringVarP(&K8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
 
 	/*
 		switch common.CMMayflyMode {

--- a/src/cmd/k8s/uninstallWeaveScope.go
+++ b/src/cmd/k8s/uninstallWeaveScope.go
@@ -1,4 +1,4 @@
-package framework
+package k8s
 
 import (
 	"fmt"
@@ -22,35 +22,27 @@ var uninstallWeaveScopeCmd = &cobra.Command{
 		common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 
 		var cmdStr string
-		switch common.CMMayflyMode {
-		case common.ModeDockerCompose:
-			fmt.Println("cm-mayfly Docker Compose mode does not support 'weave-scope uninstall' subcommand.")
 
-		case common.ModeKubernetes:
-			// If your cluster is on GKE, first you need to grant permissions for the uninstallation.
-			if strings.ToLower(root.K8sprovider) == "gke" {
-				cmdStr = `kubectl delete clusterrolebinding "cluster-admin-$(whoami)"`
-				common.SysCall(cmdStr)
-			}
+		// If your cluster is on GKE, first you need to grant permissions for the uninstallation.
+		if strings.ToLower(root.K8sprovider) == "gke" {
+			cmdStr = `kubectl delete clusterrolebinding "cluster-admin-$(whoami)"`
+			common.SysCall(cmdStr)
+		}
 
-			if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "eks" || strings.ToLower(root.K8sprovider) == "aks" {
+		if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "eks" || strings.ToLower(root.K8sprovider) == "aks" {
 
-				// Uninstall Weave Scope on your Kubernetes cluster.
-				cmdStr = `kubectl delete -f "https://cloud.weave.works/k8s/scope.yaml?k8s-version=$(kubectl version | base64 | tr -d '\n')&k8s-service-type=LoadBalancer"`
-				common.SysCall(cmdStr)
+			// Uninstall Weave Scope on your Kubernetes cluster.
+			cmdStr = `kubectl delete -f "https://cloud.weave.works/k8s/scope.yaml?k8s-version=$(kubectl version | base64 | tr -d '\n')&k8s-service-type=LoadBalancer"`
+			common.SysCall(cmdStr)
 
-				fmt.Print(`Weave Scope uninstalled successfully.`)
+			fmt.Print(`Weave Scope uninstalled successfully.`)
 
-			} else {
-				// Uninstall Weave Scope on your Kubernetes cluster.
-				cmdStr = `kubectl delete -f "https://cloud.weave.works/k8s/scope.yaml?k8s-version=$(kubectl version | base64 | tr -d '\n')&k8s-service-type=NodePort"`
-				common.SysCall(cmdStr)
+		} else {
+			// Uninstall Weave Scope on your Kubernetes cluster.
+			cmdStr = `kubectl delete -f "https://cloud.weave.works/k8s/scope.yaml?k8s-version=$(kubectl version | base64 | tr -d '\n')&k8s-service-type=NodePort"`
+			common.SysCall(cmdStr)
 
-				fmt.Print(`Weave Scope uninstalled successfully.`)
-			}
-
-		default:
-
+			fmt.Print(`Weave Scope uninstalled successfully.`)
 		}
 
 	},

--- a/src/cmd/k8s/update.go
+++ b/src/cmd/k8s/update.go
@@ -1,4 +1,4 @@
-package framework
+package k8s
 
 import (
 	"fmt"
@@ -25,20 +25,13 @@ var updateCmd = &cobra.Command{
 			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
 
 			var cmdStr string
-			switch common.CMMayflyMode {
-			case common.ModeDockerCompose:
-				fmt.Println("cm-mayfly Docker Compose mode does not support 'update/apply' subcommand.")
 
-			case common.ModeKubernetes:
-				cmdStr = fmt.Sprintf("helm upgrade --namespace %s --install %s -f %s ../helm-chart", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
-				if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "aks" {
-					cmdStr += " --set metricServer.enabled=false"
-				}
-				//fmt.Println(cmdStr)
-				common.SysCall(cmdStr)
-			default:
-
+			cmdStr = fmt.Sprintf("helm upgrade --namespace %s --install %s -f %s ../helm-chart", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
+			if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "aks" {
+				cmdStr += " --set metricServer.enabled=false"
 			}
+			//fmt.Println(cmdStr)
+			common.SysCall(cmdStr)
 
 		}
 

--- a/src/cmd/k8s/update.go
+++ b/src/cmd/k8s/update.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	root "github.com/cm-mayfly/cm-mayfly/src/cmd"
 	"github.com/cm-mayfly/cm-mayfly/src/common"
 	"github.com/spf13/cobra"
 )
@@ -19,15 +18,13 @@ var updateCmd = &cobra.Command{
 		fmt.Println("\n[Update Cloud-Migrator]")
 		fmt.Println()
 
-		if common.FileStr == "" {
+		if common.K8sFilePath == "" {
 			fmt.Println("file is required")
 		} else {
-			common.FileStr = common.GenConfigPath(common.FileStr, common.CMMayflyMode)
-
 			var cmdStr string
 
-			cmdStr = fmt.Sprintf("helm upgrade --namespace %s --install %s -f %s ../helm-chart", common.CMK8sNamespace, common.CMHelmReleaseName, common.FileStr)
-			if strings.ToLower(root.K8sprovider) == "gke" || strings.ToLower(root.K8sprovider) == "aks" {
+			cmdStr = fmt.Sprintf("helm upgrade --namespace %s --install %s -f %s ../helm-chart", common.CMK8sNamespace, common.CMHelmReleaseName, common.K8sFilePath)
+			if strings.ToLower(K8sprovider) == "gke" || strings.ToLower(K8sprovider) == "aks" {
 				cmdStr += " --set metricServer.enabled=false"
 			}
 			//fmt.Println(cmdStr)
@@ -42,8 +39,8 @@ func init() {
 	//rootCmd.AddCommand(updateCmd)
 
 	pf := updateCmd.PersistentFlags()
-	pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
-	pf.StringVarP(&root.K8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
+	pf.StringVarP(&common.K8sFilePath, "file", "f", common.DefaultKubernetesConfig, "User-defined configuration file")
+	pf.StringVarP(&K8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
 
 	//	cobra.MarkFlagRequired(pf, "file")
 

--- a/src/cmd/k8s/weave-scope.go
+++ b/src/cmd/k8s/weave-scope.go
@@ -3,8 +3,6 @@ package k8s
 import (
 	"fmt"
 
-	root "github.com/cm-mayfly/cm-mayfly/src/cmd"
-
 	"github.com/cm-mayfly/cm-mayfly/src/common"
 	"github.com/spf13/cobra"
 )
@@ -30,8 +28,8 @@ func init() {
 	//rootCmd.AddCommand(weaveScopeCmd)
 
 	pf := weaveScopeCmd.PersistentFlags()
-	// pf.StringVarP(&common.FileStr, "file", "f", common.NotDefined, "User-defined configuration file")
-	pf.StringVarP(&root.K8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
+	//pf.StringVarP(&common.K8sFilePath, "file", "f", common.NotDefined, "User-defined configuration file")
+	pf.StringVarP(&K8sprovider, "k8sprovider", "", common.NotDefined, "Kind of Managed K8s services")
 
 	/*
 		switch common.CMMayflyMode {

--- a/src/cmd/k8s/weave-scope.go
+++ b/src/cmd/k8s/weave-scope.go
@@ -1,4 +1,4 @@
-package framework
+package k8s
 
 import (
 	"fmt"
@@ -16,22 +16,13 @@ var weaveScopeCmd = &cobra.Command{
 	Long:  `Subcommand for managing Weave Scope`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		switch common.CMMayflyMode {
-		case common.ModeDockerCompose:
-			fmt.Println("cm-mayfly Docker Compose mode does not support 'uninstall-weave-scope' subcommand.")
+		fmt.Println("")
+		fmt.Println("'./mayfly weave-scope' subcommand provides these subsubcommands:")
+		fmt.Println("")
+		fmt.Println("'./mayfly weave-scope install': Install and expose Weave Scope on your K8s cluster.")
+		fmt.Println("'./mayfly weave-scope uninstall': Uninstall Weave Scope on your K8s cluster.")
+		fmt.Println("")
 
-		case common.ModeKubernetes:
-
-			fmt.Println("")
-			fmt.Println("'./mayfly weave-scope' subcommand provides these subsubcommands:")
-			fmt.Println("")
-			fmt.Println("'./mayfly weave-scope install': Install and expose Weave Scope on your K8s cluster.")
-			fmt.Println("'./mayfly weave-scope uninstall': Uninstall Weave Scope on your K8s cluster.")
-			fmt.Println("")
-
-		default:
-
-		}
 	},
 }
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -11,7 +11,6 @@ import (
 )
 
 var cfgFile string
-var K8sprovider string
 
 // rootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{

--- a/src/common/utility.go
+++ b/src/common/utility.go
@@ -7,21 +7,16 @@ import (
 	"os/exec"
 )
 
-// FileStr is a variable that holds path to the docker-compose.yaml.
-var FileStr string
+// DockerFilePath is a variable that holds path to the docker-compose.yaml.
+var DockerFilePath string
+
+// K8sFilePath is a variable that holds path to the helm-chart's values.yaml.
+var K8sFilePath string
 
 //var CommandStr string
 //var TargetStr string
 
-// CMMayflyMode is a variable that holds current cm-mayfly's mode.
-var CMMayflyMode string
-
 const (
-	// ModeDockerCompose is a variable that holds string indicating Docker Compose mode.
-	ModeDockerCompose = "DockerCompose"
-
-	// ModeKubernetes is a variable that holds string indicating Kubernetes mode.
-	ModeKubernetes = "Kubernetes"
 
 	// DefaultDockerComposeConfig is a variable that holds path to docker-compose.yaml
 	DefaultDockerComposeConfig = "../docker-compose-mode-files/docker-compose.yaml"
@@ -44,7 +39,7 @@ const (
 
 // SysCall executes user-passed command via system call.
 func SysCall(cmdStr string) {
-	//cmdStr := "docker-compose -f " + common.FileStr + " up"
+	//cmdStr := "docker-compose -f " + common.DockerFilePath + " up"
 	cmd := exec.Command("/bin/sh", "-c", cmdStr)
 
 	cmdReader, _ := cmd.StdoutPipe()
@@ -72,27 +67,7 @@ func SysCall(cmdStr string) {
 // SysCallDockerComposePs executes `docker-compose ps` command via system call.
 func SysCallDockerComposePs() {
 	fmt.Println("\n[v]Status of Cloud-Migrator runtimes")
-	//cmdStr := "COMPOSE_PROJECT_NAME=cm-mayfly docker-compose -f " + FileStr + " ps"
-	cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps", CMComposeProjectName, FileStr)
+	//cmdStr := "COMPOSE_PROJECT_NAME=cm-mayfly docker-compose -f " + DockerFilePath + " ps"
+	cmdStr := fmt.Sprintf("COMPOSE_PROJECT_NAME=%s docker compose -f %s ps", CMComposeProjectName, DockerFilePath)
 	SysCall(cmdStr)
-}
-
-// GenConfigPath receives path-to-config-file and cm-mayfly-mode, and returns path-to-config-file.
-func GenConfigPath(fileStr string, mode string) string {
-	returnStr := fileStr
-	switch mode {
-	case ModeDockerCompose:
-		if fileStr == NotDefined {
-			returnStr = DefaultDockerComposeConfig
-		}
-	case ModeKubernetes:
-		if fileStr == NotDefined {
-			returnStr = DefaultKubernetesConfig
-		}
-	default:
-
-	}
-	fmt.Println("[Config path] " + returnStr)
-	fmt.Println()
-	return returnStr
 }

--- a/src/main.go
+++ b/src/main.go
@@ -16,103 +16,10 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-
 	"github.com/cm-mayfly/cm-mayfly/src/cmd"
 	_ "github.com/cm-mayfly/cm-mayfly/src/cmd/docker"
-	"github.com/cm-mayfly/cm-mayfly/src/common"
 )
 
-func errCheck(e error) {
-	if e != nil {
-		panic(e)
-	}
-}
-
-func scanAndWriteMode() {
-
-	fmt.Println("")
-	fmt.Println("[Options]")
-	fmt.Println("1: Docker Compose environment (Requires Docker and Docker Compose)")
-	fmt.Println("2: Kubernetes environment (Requires Kubernetes cluster with Helm 3)")
-	fmt.Println("")
-	fmt.Print("Choose 1 or 2: ")
-
-	var userInput uint8
-	fmt.Scanf("%d", &userInput)
-
-	var tempStr string
-
-	switch userInput {
-	case 1:
-		fmt.Println("[1: Docker Compose environment (Requires Docker and Docker Compose)] selected.")
-		tempStr = common.ModeDockerCompose
-	case 2:
-		fmt.Println("[2: Kubernetes environment (Requires Kubernetes cluster with Helm 3)] selected.")
-		tempStr = common.ModeKubernetes
-	default:
-		fmt.Println("You should choose between 1 and 2.")
-		return
-	}
-
-	err := ioutil.WriteFile("./CM_OPERATOR_MODE", []byte(tempStr), os.FileMode(0644))
-	errCheck(err)
-
-	fmt.Println("")
-	fmt.Println("CM_OPERATOR_MODE is set to: " + tempStr)
-	fmt.Println("To change CM_OPERATOR_MODE, just delete the CM_OPERATOR_MODE file and re-run the cm-mayfly.")
-}
-
-func readMode() string {
-	if _, err := os.Stat("./CM_OPERATOR_MODE"); err == nil {
-		// if file exists
-		data, err := ioutil.ReadFile("./CM_OPERATOR_MODE")
-		errCheck(err)
-
-		common.CMMayflyMode = string(data)
-		//fmt.Println("CM_OPERATOR_MODE File mode : " + common.CMMayflyMode)
-
-		//if common.CMMayflyMode == common.DockerCompose || common.CMMayflyMode == common.Kubernetes {
-		return common.CMMayflyMode
-		//}
-
-	} else if os.IsNotExist(err) {
-		// path/to/whatever does *not* exist
-		fmt.Println("CM_OPERATOR_MODE file does not exist.")
-		scanAndWriteMode()
-		result := readMode()
-		return result
-
-	} else {
-		// Schrodinger: file may or may not exist. See err for details.
-
-		// Therefore, do *NOT* use !os.IsNotExist(err) to test for file existence
-
-		errCheck(err)
-		return ""
-	}
-	//return ""
-}
-
-//var CMMayflyMode string
-
 func main() {
-
-	mode := readMode()
-	//mode := common.ModeDockerCompose
-	switch mode {
-	case common.ModeDockerCompose:
-		cmd.Execute()
-	case common.ModeKubernetes:
-		cmd.Execute()
-	default:
-		fmt.Println("Invalid CM_OPERATOR_MODE: " + mode)
-		fmt.Println("CM_OPERATOR_MODE should be one of these: " + common.ModeDockerCompose + ", " + common.ModeKubernetes)
-
-		scanAndWriteMode()
-		main()
-	}
-
+	cmd.Execute()
 }


### PR DESCRIPTION
# 작업 개요
- 최신 도커 컴포즈 태그로의 업데이트 및 cm-beetle 추가
- 도커와 쿠버네티스 서브 커맨드 분리
- 도커와 쿠버네티스 모드 구분 코드의 정리
 
# 변경 사항
도커 컴포즈 최신 태그 및 cm-beetle 추가: 이전에 사용 중이던 도커 컴포즈를 최신 태그로 업데이트하고, cm-beetle을 추가하였습니다.

도커와 쿠버네티스 서브 커맨드 분리: mayfly 의 서브 커맨드인 docker 와 k8s 를 패키지와 커맨드를 분리하였습니다.

도커와 쿠버네티스 모드 구분 코드 정리: 프로젝트 내의 도커와 쿠버네티스 모드를 구분하는 코드를 정리하여 가독성을 향상시켰습니다.

# 테스트
이 변경 사항은 로컬 환경에서 테스트되었으며, 기존 기능에 영향을 미치지 않고 예상대로 작동함을 확인하였습니다.

