### PR TITLE
add makefile in project root directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: default
+default:
+	@cd src && $(MAKE) default
+
+.PHONY: linux-arm
+linux-arm:
+	@cd src && $(MAKE) linux-arm
+
+#windows 64bint
+.PHONY: win
+win:
+	@cd src && $(MAKE) win
+
+#windows 32bit
+.PHONY: win86
+win86:
+	@cd src && $(MAKE) win86
+
+.PHONY: mac
+mac:
+	@cd src && $(MAKE) mac
+
+.PHONY: mac-arm
+mac-arm:
+	@cd src && $(MAKE) mac-arm
+
+.PHONY: clean
+clean:
+	@cd src && $(MAKE) clean
+


### PR DESCRIPTION
As per [planning for applying ci/cd migrator subsystem](https://github.com/cloud-barista/cloud-migrator/issues/8), create makefile on the project root

# 작업내용
src 디렉토리의 Makefile 의 사용을 위해 project root 에서 빌드 가능한 Makefile 작성
