### PR TITLE
ci: AI 흔적 자동 차단 워크플로우 추가

### DIFF
--- a/.github/workflows/no-ai-trace.yml
+++ b/.github/workflows/no-ai-trace.yml
@@ -1,0 +1,143 @@
+name: AI Trace Check
+
+# C-Mig policy enforcement: prevent AI tool attribution (Claude, Anthropic, Copilot, etc.)
+# from being merged into protected branches of C-Mig related repositories.
+#
+# Canonical source: https://github.com/MZC-CSC/cmig-workflow/blob/main/conf/workflow-templates/no-ai-trace.yml
+# Policy document:  https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-AI-TRACE-GUARD.md
+# Target location in each repo: .github/workflows/no-ai-trace.yml
+
+on:
+  pull_request:
+    branches: [main, develop, master]
+  push:
+    branches: [main, develop, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  block-ai-trace:
+    name: Block AI tool attribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine commit range to scan
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "from=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "to=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
+              echo "from=${{ github.sha }}~1" >> $GITHUB_OUTPUT
+            else
+              echo "from=$BEFORE" >> $GITHUB_OUTPUT
+            fi
+            echo "to=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Scan commits for AI tool attribution
+        id: scan
+        run: |
+          FROM="${{ steps.range.outputs.from }}"
+          TO="${{ steps.range.outputs.to }}"
+
+          # Patterns matched against commit message body and trailers
+          BODY_PATTERNS='Co-Authored-By:.*[Cc]laude|Co-Authored-By:.*[Aa]nthropic|Co-Authored-By:.*[Cc]opilot|Generated-By:.*[Cc]laude|Generated-By:.*[Cc]ode|Assisted-By|Co-Developed-By|noreply@anthropic\.com'
+
+          # Patterns matched against author and committer email
+          EMAIL_PATTERNS='@anthropic\.com|copilot-swe-agent'
+
+          FOUND=""
+          for sha in $(git rev-list "$FROM..$TO" 2>/dev/null); do
+            SUBJECT=$(git log -1 --pretty='%s' "$sha")
+            BODY=$(git log -1 --pretty='%B' "$sha")
+            AUTHOR_EMAIL=$(git log -1 --pretty='%ae' "$sha")
+            COMMITTER_EMAIL=$(git log -1 --pretty='%ce' "$sha")
+
+            BAD=""
+            HIT=$(echo "$BODY" | grep -iE "$BODY_PATTERNS" | head -3)
+            if [ -n "$HIT" ]; then
+              BAD="$BAD"$'\n'"  - body/trailer match:"$'\n'"$(echo "$HIT" | sed 's/^/      /')"
+            fi
+
+            for email in "$AUTHOR_EMAIL" "$COMMITTER_EMAIL"; do
+              if echo "$email" | grep -iqE "$EMAIL_PATTERNS"; then
+                BAD="$BAD"$'\n'"  - AI tool email match: $email"
+              fi
+            done
+
+            if [ -n "$BAD" ]; then
+              FOUND="$FOUND"$'\n\n'"### $sha"$'\n'"  subject: $SUBJECT$BAD"
+            fi
+          done
+
+          if [ -n "$FOUND" ]; then
+            {
+              echo "found=true"
+              echo "details<<EOF"
+              echo "$FOUND"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+
+            echo "::error::AI tool attribution detected. See logs and PR comment for details."
+            echo "$FOUND"
+            exit 1
+          fi
+
+          echo "found=false" >> $GITHUB_OUTPUT
+          echo "OK: no AI tool attribution found."
+
+      - name: Post failure comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const details = `${{ steps.scan.outputs.details }}`;
+            const body = [
+              '## AI Trace Check Failed',
+              '',
+              'This PR contains commits with AI tool attribution that violates the project policy.',
+              '',
+              '<details><summary>Matched commits</summary>',
+              '',
+              '```',
+              details,
+              '```',
+              '',
+              '</details>',
+              '',
+              '### How to fix',
+              '',
+              '**Most recent commit only** - strip the attribution trailers:',
+              '```bash',
+              'git commit --amend --message="$(git log -1 --pretty=\'%s%n%n%b\' | grep -vE \'Co-Authored-By:|Generated-By:|Assisted-By:|Co-Developed-By:\')"',
+              'git push --force-with-lease',
+              '```',
+              '',
+              '**Multiple commits** - use interactive rebase:',
+              '```bash',
+              'git rebase -i HEAD~5   # last 5 commits',
+              '# Mark each commit as `reword` and remove the trailer lines in the editor',
+              'git push --force-with-lease',
+              '```',
+              '',
+              'The check will re-run automatically after you push the fixed commits.',
+              '',
+              '### Policy reference',
+              '',
+              '- Project policy: AI tool attribution must not be exposed in any C-Mig related git repository.',
+              '- [POLICY-AI-TRACE-GUARD](https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-AI-TRACE-GUARD.md)'
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });


### PR DESCRIPTION
## 배경

본 PR은 commit history에 AI 도구(Claude, Anthropic, GitHub Copilot 등)의 작성 흔적이 노출되지 않도록 PR 단계에서 자동으로 검증하는 GitHub Actions 워크플로우를 추가합니다.

## 변경 사항

- 신규: `.github/workflows/no-ai-trace.yml`
- 트리거: `main`, `develop`, `master` 브랜치 대상 push + pull_request
- 검사 대상: commit message·body·trailer + author/committer email
- 매치 패턴: `Co-Authored-By: Claude/Anthropic/Copilot`, `Generated-By: Claude/Code`, `Assisted-By`, `Co-Developed-By`, `noreply@anthropic.com`, `copilot-swe-agent[bot]` 등
- 매치 발생 시 status check 실패 + PR 코멘트 자동 생성 (정책 링크 + 수정 명령 안내)

## 머지 후 필수 후속 작업

본 워크플로우는 *감지·알림*만 합니다. 실제 머지 차단을 위해 `Settings → Branches`에서 각 보호 브랜치에 *별도로* Branch Protection rule을 추가해야 합니다.

- ☑ Require a pull request before merging
- ☑ Require status checks to pass before merging → 필수 status: `Block AI tool attribution`
- ☑ Require linear history
- ☑ Do not allow bypassing the above settings

## 개발자 가이드

작성 중인 commit에 AI 도구 trailer가 자동으로 추가되는 경우 다음 방법으로 끕니다.

### GitHub Copilot

- VSCode/JetBrains: `Settings → GitHub Copilot → Commit message generation` 비활성화
- PR에서 Copilot 사용 시: `Settings → Co-author with Copilot in pull requests` 비활성화

### Cursor / Windsurf

- Settings에서 AI 어시스턴트 commit attribution 옵션 비활성화 (메뉴 명칭은 버전마다 다름)

### git 전역 안전장치 (도구 무관)

```bash
git config --global commit.cleanup strip
```

### 이미 push한 commit에서 흔적을 제거하는 방법

가장 최근 commit 1건만:

```bash
git commit --amend --message="$(git log -1 --pretty='%s%n%n%b' | grep -vE 'Co-Authored-By:|Generated-By:|Assisted-By:|Co-Developed-By:')"
git push --force-with-lease
```

여러 건 일괄 처리 (interactive rebase):

```bash
git rebase -i HEAD~5
# 각 commit을 `reword`로 설정 → 편집기에서 trailer 라인 삭제
git push --force-with-lease
```

수정 push 후 Actions가 자동으로 재실행됩니다.

---

## MZC 관련 정책

- 핵심 원칙: cmig-workflow 본 저장소 외 모든 C-Mig 관련 git 저장소에 *AI의 존재를 노출하지 않는다*. 모든 작업은 사람이 수행한 것처럼 동작한다.
- 정책 문서: [POLICY-AI-TRACE-GUARD](https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-AI-TRACE-GUARD.md)
- 정책 신설일: 2026-06-10
- cmig-workflow Task: 001_AI흔적-MZC-fork정리
- JIRA: BAR-860

표준 yaml 원본·갱신은 [cmig-workflow/conf/workflow-templates/no-ai-trace.yml](https://github.com/MZC-CSC/cmig-workflow/blob/main/conf/workflow-templates/no-ai-trace.yml)에서 관리합니다. 본 원본이 갱신되면 본 저장소의 파일도 원본에서 다시 동기화합니다.