### PR TITLE
fix(docker): map .env vars into cm-ant and airflow-server runtime environment

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -701,7 +701,9 @@ services:
         - ./conf/cm-cicada/_airflow/create_airflow_db.sql:/docker-entrypoint-initdb.d/create_airflow_db.sql
         - ./data/cm-cicada/db_data:/var/lib/mysql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "airflow", "-pairflow_pass" ]
+      # Use the centrally-managed .env credentials instead of hardcoded ones,
+      # so the healthcheck stays in sync with whatever .env supplies to MYSQL_USER/PASSWORD.
+      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u $${MYSQL_USER} -p$${MYSQL_PASSWORD}" ]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -730,6 +732,14 @@ services:
         - MYSQL_PASSWORD=${AIRFLOW_DB_PASSWORD}
         - MYSQL_HOST=airflow-mysql
         - MYSQL_DATABASE=${AIRFLOW_DB_NAME}
+        # AIRFLOW__{CORE,DATABASE}__SQL_ALCHEMY_CONN explicitly override airflow.cfg, which
+        # otherwise keeps its built-in default of mysql://airflow:airflow_pass@airflow-mysql/airflow
+        # regardless of the MYSQL_* variables above. Without these airflow-server fails with
+        # "Access denied for user 'airflow'" whenever .env values differ from the hardcoded defaults
+        # — same shape as the cm-ant ANT_DATABASE_* gap above. Both CORE (deprecated alias still
+        # consulted in 2.x) and DATABASE keys are set so the override holds across version bumps.
+        - AIRFLOW__CORE__SQL_ALCHEMY_CONN=mysql+mysqldb://${AIRFLOW_DB_USER}:${AIRFLOW_DB_PASSWORD}@airflow-mysql/${AIRFLOW_DB_NAME}
+        - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=mysql+mysqldb://${AIRFLOW_DB_USER}:${AIRFLOW_DB_PASSWORD}@airflow-mysql/${AIRFLOW_DB_NAME}
     ports:
         - "5555:5555"
         - "8080:8080"
@@ -841,6 +851,13 @@ services:
       - ANT_TUMBLEBUG_HOST=http://cb-tumblebug
       - ANT_TUMBLEBUG_PORT=1323
       - ANT_DATABASE_HOST=ant-postgres
+      # cm-ant Go application reads ANT_DATABASE_USER/PASSWORD/NAME (not ANT_DB_*),
+      # so remap from the shared .env names here. Without these three lines cm-ant
+      # falls back to its built-in defaults (cm-ant-user/cm-ant-secret/cm-ant-db)
+      # and authentication against ant-postgres fails whenever .env values differ.
+      - ANT_DATABASE_USER=${ANT_DB_USER}
+      - ANT_DATABASE_PASSWORD=${ANT_DB_PASSWORD}
+      - ANT_DATABASE_NAME=${ANT_DB_NAME}
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://cm-ant:8880/ant/readyz" ]
       <<: *default-health-check


### PR DESCRIPTION
## Summary

`.env`의 cm-ant·airflow-server 관련 변수가 docker-compose의 *각 컨테이너 runtime environment*로 매핑되지 않아 컨테이너가 *과거에 이미지에 박혀 있던 기본값*으로 동작하는 문제를 fix.

### 발생 시나리오

- `cp .env.example .env` 후 `.env`의 `AIRFLOW_DB_PASSWORD` 또는 `ANT_DATABASE_PASSWORD`를 *과거 기본값과 다른 값*(예: 임의의 비밀번호)으로 바꾸어 둠
- `./mayfly infra run -d` 후 healthy까지 대기
- 데이터베이스에는 `.env`에 적은 새 비밀번호가 들어가 있지만, airflow-server / cm-ant 컨테이너 안의 프로세스는 여전히 이미지에 박혀 있던 기본 자격증명을 사용해 접속을 시도
- 자격증명이 어긋나 인증이 실패하고, airflow / cm-ant가 자체적으로 *주기적으로 connection 재시도*를 반복하면서 로그가 계속 쌓임

### 변경

- `docker-compose.yaml`의 `cm-ant`·`airflow-server` `environment:` 섹션에 `.env` 매핑 추가
- airflow는 `MYSQL_*`만으로는 `airflow.cfg`의 `sql_alchemy_conn`을 override 못 하므로 `AIRFLOW__CORE__SQL_ALCHEMY_CONN`·`AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`까지 추가
- 빌드 바이너리 포함

## 검증

검증 환경에서 `.env`에 임의 비밀번호를 설정하고 fresh install — 21개 컨테이너 healthy 도달, airflow/cm-ant DB 인증 정상, 이전의 주기적 재시도 로그 사라짐 확인.

## 관련

- 업스트림 이슈: cloud-barista/cm-mayfly#131
- 내부 트래킹: BAR-1288 / BAR-1289 / BAR-1272