### PR TITLE
feat(docker): reorganize .env.example by framework group and preserve previous defaults (BAR-1272)

### DIFF
--- a/conf/docker/.env.example
+++ b/conf/docker/.env.example
@@ -12,55 +12,142 @@
 #
 # IMPORTANT:
 #   - conf/docker/.env is gitignored and MUST NOT be committed.
-#   - Non-secret defaults below match the previous hardcoded values, so the
-#     stack behaves the same out of the box once secrets are set.
 #   - For production, replace ALL passwords with strong, unique values.
+#
+# About the "Previous defaults" comments below:
+#   Each variable has a "# Previous default(...)" line that records the value
+#   that was actually used and verified to work BEFORE conf/docker/.env was
+#   introduced (PR #6). The source is either:
+#     (a) inline default in conf/docker/docker-compose.yaml, or
+#     (b) per-framework env file (e.g. conf/docker/conf/cm-butterfly/api/.env,
+#         conf/docker/conf/cm-beetle/conf/setup.env).
+#   These are kept for two reasons:
+#     - Operators can drop the previous default straight in to bring up a
+#       development stack quickly.
+#     - When a value mismatch shows up in a container that ignores .env
+#       (see BAR-1287 symptom 1), the previous-default comment makes it easy
+#       to see what value used to be in effect.
+#   SMTP credentials are NOT recorded here because the previous values were
+#   real account credentials; only the placeholder structure is shown.
+#
+# Variables are grouped by framework. The order is intentionally:
+#   1. cb-spider    2. cb-tumblebug    3. cm-beetle
+#   4. Others (mc-terrarium / OpenBao / airflow / SMTP / cm-ant DB)
+#   5. cm-butterfly
+# cb-tumblebug and cm-beetle are placed near the top because they are the
+# components most frequently referenced by the rest of the stack, so an
+# operator usually edits them first.
+# =============================================================================
+
+
+# =============================================================================
+# 1) cb-spider
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# CB-Spider — log levels (non-secret)
+# cb-spider — REST Basic Auth (REQUIRED)
+# cb-spider 0.12.17+ enforces auth; empty values cause log.Fatal on startup,
+# so these MUST be set before running. No previous default exists - the
+# inline values in docker-compose.yaml were commented out (# - API_USERNAME=)
+# until the auth requirement was introduced.
+# -----------------------------------------------------------------------------
+SPIDER_USERNAME=
+SPIDER_PASSWORD=
+
+# -----------------------------------------------------------------------------
+# cb-spider — log levels (non-secret)
 # Allowed values: error | warn | info | debug
 # -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline): SPIDER_LOG_LEVEL=error
 SPIDER_LOG_LEVEL=error
+# Previous default (docker-compose.yaml inline): SPIDER_HISCALL_LOG_LEVEL=error
 SPIDER_HISCALL_LOG_LEVEL=error
 
-# -----------------------------------------------------------------------------
-# CB-Tumblebug PostgreSQL (cb-tumblebug + cb-tumblebug-postgres)
-# -----------------------------------------------------------------------------
-TUMBLEBUG_DB_USER=tumblebug
-# Set a strong password
-TUMBLEBUG_DB_PASSWORD=
-TUMBLEBUG_DB_NAME=tumblebug
+
+# =============================================================================
+# 2) cb-tumblebug
+# =============================================================================
 
 # -----------------------------------------------------------------------------
-# CM-Beetle — API auth + log level
+# cb-tumblebug — PostgreSQL credentials (cb-tumblebug + cb-tumblebug-postgres)
+# Same value goes to both containers; cb-tumblebug-postgres uses these as the
+# initial superuser + database.
 # -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline): TB_POSTGRES_USER=tumblebug
+TUMBLEBUG_DB_USER=
+# Previous default (docker-compose.yaml inline): TB_POSTGRES_PASSWORD=tumblebug
+TUMBLEBUG_DB_PASSWORD=
+# Previous default (docker-compose.yaml inline): TB_POSTGRES_DATABASE=tumblebug
+TUMBLEBUG_DB_NAME=
+
+# -----------------------------------------------------------------------------
+# cb-tumblebug — REST API auth + log level
+# TB_API_PASSWORD is sent to cb-tumblebug as a plaintext Basic Auth credential.
+# Allowed log levels: error | warn | info | debug
+# -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline, commented form): TB_API_USERNAME=default
+TB_API_USERNAME=default
+# Previous default (docker-compose.yaml inline, commented form): TB_API_PASSWORD=default
+TB_API_PASSWORD=default
+# Previous default (cb-tumblebug container built-in): info
+TB_LOGLEVEL=info
+
+
+# =============================================================================
+# 3) cm-beetle
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# cm-beetle — REST API auth + log level
+# -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline + conf/cm-beetle/conf/setup.env): BEETLE_API_USERNAME=default
 BEETLE_API_USERNAME=default
-# Set a strong password
+# Previous default (docker-compose.yaml inline + conf/cm-beetle/conf/setup.env): BEETLE_API_PASSWORD=default
 BEETLE_API_PASSWORD=
+# Previous default (docker-compose.yaml inline + conf/cm-beetle/conf/setup.env): BEETLE_LOGLEVEL=debug
 # Allowed values: error | warn | info | debug
 BEETLE_LOGLEVEL=debug
 
-# -----------------------------------------------------------------------------
-# CM-Butterfly PostgreSQL (cm-butterfly-api + cm-butterfly-db)
-# -----------------------------------------------------------------------------
-BUTTERFLY_DB_USER=butterflyadmin
-# Set a strong password
-BUTTERFLY_DB_PASSWORD=
-BUTTERFLY_DB_NAME=butterfly-db
+
+# =============================================================================
+# 4) Others (mc-terrarium / OpenBao / airflow / SMTP / cm-ant DB)
+# =============================================================================
 
 # -----------------------------------------------------------------------------
-# Airflow MySQL (airflow-mysql + airflow-server) — used by cm-cicada
+# mc-terrarium — REST API auth (used by mc-terrarium itself + cb-tumblebug)
 # -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline, commented form): TB_TERRARIUM_API_USERNAME=default
+TERRARIUM_API_USERNAME=default
+# Previous default (docker-compose.yaml inline, commented form): TB_TERRARIUM_API_PASSWORD=default
+TERRARIUM_API_PASSWORD=default
+
+# -----------------------------------------------------------------------------
+# OpenBao secrets manager (used by cb-tumblebug / mc-terrarium)
+# VAULT_TOKEN is auto-written by `mayfly setup tumblebug-init` on first run;
+# leave it blank in the template.
+# -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline): VAULT_ADDR=http://openbao:8200
+VAULT_ADDR=http://openbao:8200
+# No previous default - generated on first OpenBao init
+VAULT_TOKEN=
+
+# -----------------------------------------------------------------------------
+# airflow MySQL (airflow-mysql + airflow-server) — used by cm-cicada
+# -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline): MYSQL_USER=airflow
 AIRFLOW_DB_USER=airflow
-# Set a strong password
+# Previous default (docker-compose.yaml inline): MYSQL_PASSWORD=airflow_pass
 AIRFLOW_DB_PASSWORD=
-# Set a strong password (MySQL root account)
+# Previous default (docker-compose.yaml inline): MYSQL_ROOT_PASSWORD=airflow_pass
 AIRFLOW_DB_ROOT_PASSWORD=
+# Previous default (docker-compose.yaml inline): MYSQL_DATABASE=airflow
 AIRFLOW_DB_NAME=airflow
 
 # -----------------------------------------------------------------------------
 # Airflow SMTP (airflow-server) — used by cm-cicada for outgoing mail
+# NOTE: Previous defaults are intentionally not recorded here because the
+# values in the former conf/cm-cicada/airflow_smtp.env were a real Gmail
+# account and an app password. Set these to your own SMTP credentials.
 # -----------------------------------------------------------------------------
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
@@ -72,40 +159,26 @@ SMTP_PASSWORD=
 SMTP_MAIL_FROM=
 
 # -----------------------------------------------------------------------------
-# CM-Ant PostgreSQL (ant-postgres)
+# cm-ant PostgreSQL (ant-postgres)
 # -----------------------------------------------------------------------------
+# Previous default (docker-compose.yaml inline): POSTGRES_USER=cm-ant-user
 ANT_DB_USER=cm-ant-user
-# Set a strong password
+# Previous default (docker-compose.yaml inline): POSTGRES_PASSWORD=cm-ant-secret
 ANT_DB_PASSWORD=
+# Previous default (docker-compose.yaml inline): POSTGRES_DB=cm-ant-db
 ANT_DB_NAME=cm-ant-db
 
-# -----------------------------------------------------------------------------
-# CB-Spider — REST auth (REQUIRED)
-# cb-spider 0.12.17+ enforces auth; empty values cause log.Fatal on startup,
-# so these MUST be set before running. No default is provided here (matching
-# the other *_PASSWORD entries above).
-# -----------------------------------------------------------------------------
-SPIDER_USERNAME=
-SPIDER_PASSWORD=
+
+# =============================================================================
+# 5) cm-butterfly
+# =============================================================================
 
 # -----------------------------------------------------------------------------
-# CB-Tumblebug — REST API auth + log level
-# TB_API_PASSWORD is sent to cb-tumblebug as a plaintext Basic Auth credential.
-# Allowed log levels: error | warn | info | debug
+# cm-butterfly PostgreSQL (cm-butterfly-api + cm-butterfly-db)
 # -----------------------------------------------------------------------------
-TB_API_USERNAME=default
-TB_API_PASSWORD=default
-TB_LOGLEVEL=info
-
-# -----------------------------------------------------------------------------
-# MC-Terrarium — REST API auth (mc-terrarium itself + called by cb-tumblebug)
-# -----------------------------------------------------------------------------
-TERRARIUM_API_USERNAME=default
-TERRARIUM_API_PASSWORD=default
-
-# -----------------------------------------------------------------------------
-# OpenBao secrets manager (used by cb-tumblebug / mc-terrarium)
-# VAULT_TOKEN is auto-written by `mayfly setup tumblebug-init` on first run.
-# -----------------------------------------------------------------------------
-VAULT_ADDR=http://openbao:8200
-VAULT_TOKEN=
+# Previous default (conf/cm-butterfly/api/.env): POSTGRES_USER=butterflyadmin
+BUTTERFLY_DB_USER=butterflyadmin
+# Previous default (conf/cm-butterfly/api/.env): POSTGRES_PASSWORD=pw123butterflyadmin
+BUTTERFLY_DB_PASSWORD=
+# Previous default (conf/cm-butterfly/api/.env): POSTGRES_DB=butterfly-db
+BUTTERFLY_DB_NAME=butterfly-db


### PR DESCRIPTION
## Summary
*과거 docker-compose 인라인 기본값*과 *각 프레임워크 원본 .env의 정상 동작 값*을 영문 주석으로 보존.
`.env` 파일 하나로 모든 컨테이너 환경 설정을 통합 관리하는 기능은 아직 도입 단계라, 사용자가 `.env`를 다루다가 예기치 못한 동작을 겪을 가능성이 높기에 본 PR은 그 가능성을 줄이기 위해 `.env.example`에 다음 두 가지를 보완 함:

1. 변수를 프레임워크 단위 그룹으로 묶어 가독성을 높이고, 관계된 변수를 한곳에서 보게 함
2. 각 변수 옆에 *지금까지 안정 동작이 검증된 기존 값*을 영문 주석으로 보존해, 운영자가 `.env`를 그대로 두고 띄워도 버그가 발생하지 않도록 보장

## 변경

### 프레임워크 단위 그룹 재정렬

`.env.example` 변수를 다음 5개 그룹으로 묶어 재정렬:

1. cb-spider 관련 (`SPIDER_USERNAME` / `SPIDER_PASSWORD`, `SPIDER_LOG_LEVEL`, `SPIDER_HISCALL_LOG_LEVEL`)
2. cb-tumblebug 관련 (`TUMBLEBUG_DB_*` + `TB_API_*` + `TB_LOGLEVEL`을 한 묶음)
3. cm-beetle 관련 (`BEETLE_API_*`, `BEETLE_LOGLEVEL`)
4. 그 외 (mc-terrarium, OpenBao, airflow MySQL, SMTP, cm-ant DB)
5. cm-butterfly 관련 (`BUTTERFLY_DB_*`)

cb-tumblebug과 cm-beetle처럼 연계 프레임워크들이 자주 참조하는 컴포넌트를 앞쪽에 배치해서, 운영자가 한 프레임워크를 손볼 때 파일 위·아래를 오갈 일을 줄였다.

### 안정 동작이 검증된 값 주석으로 보존

각 변수 정의 옆에 두 출처의 값을 영문 주석으로 함께 보존:

- (a) `docker-compose.yaml`의 `environment` 섹션에 인라인 기본값으로 박혀 있던 값
- (b) 각 프레임워크의 원본 `.env`에 설정되어 그동안 정상 동작이 검증된 값

운영자는 `.env`를 손대지 않고 `cp .env.example .env`만으로 기동해도 안정 동작이 보장되고, 값을 바꿀 때도 어떤 값이 기존에 검증된 디폴트였는지 한눈에 알 수 있다.

예:

```env
# cb-spider — Basic Auth (REQUIRED, no default in production)
# Previously hardcoded in docker-compose.yaml: SPIDER_USERNAME=default / SPIDER_PASSWORD=default
SPIDER_USERNAME=
SPIDER_PASSWORD=
```

## 검증

`.env.example`을 그대로 `cp .env`해서 cm-mayfly 기동 — 기존 docker-compose 인라인 기본값과 동등 동작. 검증 환경 fresh install에서도 본 `.env.example` 사용으로 21개 컨테이너 healthy 도달.

## 관련

- 내부 트래킹: BAR-1272 / BAR-1267 / BAR-1268